### PR TITLE
Switch from scudo to jemalloc for improved performance

### DIFF
--- a/roomservice.xml
+++ b/roomservice.xml
@@ -40,6 +40,12 @@
   <!-- Contains a patch bringing back legacy FunctionFS support for ADB - REQUIRED -->
   <remove-project name="LineageOS/android_packages_modules_adb" />
   <project name="K9100ii/android_packages_modules_adb" path="packages/modules/adb" remote="github" revision="lineage-19.1-ultralegacy" />
+
+  <!-- Contains a patch switching the default memory allocator to jemalloc for improved performance - OPTIONAL -->
+  <remove-project name="platform/external/jemalloc_new" />
+  <remove-project name="LineageOS/android_bionic" />
+  <project name="LineageOS-UL/android_external_jemalloc_new" path="external/jemalloc_new" remote="github" revision="lineage-19.1" />
+  <project name="LineageOS-UL/android_bionic" path="bionic" remote="github" revision="lineage-19.1" />
   <!-- END OF FORKS -->
 
   <!-- Open source aptX and aptX HD encoders -->


### PR DESCRIPTION
Switching from Scudo to Jemalloc can improve performance, as can be seen [here](https://github.com/LineageOS-UL/android_bionic/commit/1f383abed28ce60b73700250434c1b7488546655). I have tried it a few times in my personal s5neolte builds some time ago and saw a slight performance imrpovement (at least in synthetic in benchmarks).